### PR TITLE
feat: include latest git commit SHA in GET /api/v1/version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git/
 README.md
 .github/
 .gitignore

--- a/api/v1/system.py
+++ b/api/v1/system.py
@@ -4,22 +4,29 @@ import logging
 from pkg import config
 from yaml import load
 
+import git
+
 logger = logging.getLogger('api.v1.system')
 
 # First fetch to /api/v1/version will cache this
 config.VERSION_NUMBER = None
 
-
 def get_version():
+    if config.VERSION_HASH is None:
+        try:
+            repo = git.Repo(search_parent_directories=True)
+            config.VERSION_HASH = repo.head.object.hexsha
+        except:
+            pass
+
     if config.VERSION_NUMBER is None:
         try:
             with open(config.SWAGGER_URL) as f:
                 yaml_str = f.read()
                 yaml_spec = load(yaml_str)
                 config.VERSION_NUMBER = yaml_spec['info']['version']
-                return config.VERSION_NUMBER, 200
         except:
-            return 'unknown', 404
-    else:
-        return config.VERSION_NUMBER, 200
+            pass
+
+    return {'version': config.VERSION_NUMBER, 'hash': config.VERSION_HASH}, 200
 

--- a/pkg/config.py
+++ b/pkg/config.py
@@ -17,6 +17,7 @@ FRONTEND_CFG_PATH = os.getenv('FRONTEND_CFG_PATH', './env/frontend.json')
 
 # First fetch to /api/v1/version will cache this
 VERSION_NUMBER = None
+VERSION_HASH = None
 
 # Read app/env/backend.json and frontend/json
 with open(FRONTEND_CFG_PATH) as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@ kubernetes==23.6.0
 # MongoDB
 pymongo==4.0.1
 
-# Deprecated: etcd (use mongo instead)
-python-etcd==0.4.5
+# git
+gitpython==3.1.29
 
 # RabbitMQ
 rabbitpy==2.0.1


### PR DESCRIPTION
## Problem
Version number is not granular enough to tell which version of the code is running

## Approach
* Read latest commit SHA from disk and return that with `GET /api/v1/version`