### PR TITLE
fix: include envvars that have default values

### DIFF
--- a/pkg/kube.py
+++ b/pkg/kube.py
@@ -513,6 +513,8 @@ def create_userapp(username, userapp, spec_map):
                     not cfg['value']:
                 # generate password if none is provided
                 configmap_data[cfg['name']] = generate_random_password()
+            else:
+                configmap_data[cfg['name']] = cfg['value'] if 'value' in cfg else ''
 
         stack_service['config'] = configmap_data
 


### PR DESCRIPTION
## Problem
Basic config case was somehow missed: `canOverride=true` with a value set (e.g. rstudio `PASSWORD`)

## Approach
* Add an `else` clause here to set these configs when default values are provided