### PR TITLE
fix: username should not be a URL

### DIFF
--- a/pkg/auth/keycloak.py
+++ b/pkg/auth/keycloak.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import requests
 from werkzeug.exceptions import Unauthorized
@@ -53,6 +54,10 @@ def userinfo(access_token) -> dict:
                 for role in user['resource_access'][client_name]['roles']:
                     groups.append(f"role:{client_name}:{role}")
 
+        # sub = user['preferred_username'].replace('@', '').replace('.', '')
+        email = user['email']
+        username = re.sub(r'[^a-zA-Z0-9]', '', email)
+
         # TODO: oauth2-proxy does not support arbitrary claims yet, so excluding name for consistency
         # See https://github.com/oauth2-proxy/oauth2-proxy/issues/834
         return {
@@ -60,7 +65,7 @@ def userinfo(access_token) -> dict:
             'groups': groups,
             # 'family_name': user['family_name'],
             # 'given_name': user['given_name'],
-            'sub': user['preferred_username'].replace('@', '').replace('.', '')
+            'sub': username
         }
     except Exception as e:
         logger.warning("Keycloak token verification failed: " + str(e))

--- a/pkg/auth/oauth2.py
+++ b/pkg/auth/oauth2.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import requests
 import logging
@@ -35,7 +36,9 @@ def userinfo(access_token) -> dict:
         for grp in user['groups']:
             roles.append(grp)
 
-        sub = user['preferredUsername'].replace('@', '').replace('.', '')
+        # sub = user['preferredUsername'].replace('@', '').replace('.', '')
+        email = user['email']
+        username = re.sub(r'[^a-zA-Z0-9]', '', email)
 
         # TODO: Hoping that oauth2-proxy enhances support for providing arbitrary token claims from OIDC
         # See https://github.com/oauth2-proxy/oauth2-proxy/issues/834
@@ -44,7 +47,7 @@ def userinfo(access_token) -> dict:
             'groups': roles,
             # 'family_name': user['family_name'],
             # 'given_name': user['given_name'],
-            'sub': sub
+            'sub': username
         }
     except Exception as e:
         logger.warning("OAuth2 token verification failed: " + str(e))


### PR DESCRIPTION
## Problem
Sometimes when logging in with CILogon, the `preferredUsername` is set as a URL?
e.g. `http://cilogon.org/servera/users/237226`

## Approach
The correct approach might eventually be to look into why Keycloak does this, and possibly use a Mapper to replace this preferredUsername with a useful value instead. Rather than tie to another bit of Keycloak configuration (that may not ever be needed), for now just use email

* For username / sub, use the `email` sanitized with a regex to strip out non-alphanumeric characters