### PR TITLE
feat: my-catalog and add-edit-spec pages

### DIFF
--- a/api/v1/app_specs.py
+++ b/api/v1/app_specs.py
@@ -43,6 +43,16 @@ def is_service_key_unique(username, service_key):
 
 
 def create_service(service, user, token_info):
+    if not service or not service['key']:
+        return {'error': 'Invalid spec: no spec provided'}, 400
+
+    if '$oid' in service:
+        service.pop('$oid')
+    if 'id' in service:
+        service.pop('id')
+    if '_id' in service:
+        service.pop('_id')
+
     service['creator'] = user
     catalog = service['catalog'] if 'catalog' in service else 'user'
     dependencies = service['depends'] if 'depends' in service else []
@@ -50,32 +60,31 @@ def create_service(service, user, token_info):
     # Ensure that all dependencies exist
     missing_deps = []
     all_specs = data_store.fetch_all_appspecs_for_user(user)
-    logger.info("All specs: %s" % all_specs)
     for dep in dependencies:
         if len([spec['key'] for spec in all_specs if dep['key'] == spec['key']]) == 0:
             missing_deps.append(dep['key'])
 
     if len(missing_deps) > 0:
-        return {'error': 'Invalid spec: missing dependencies: %s' % missing_deps}, 400, jwt.get_token_cookie(user)
+        return {'error': 'Invalid spec: missing dependencies: %s' % missing_deps}, 400
 
     if catalog == 'user':
         if 'creator' not in service:
-            return {'error': 'User appspec must specify a creator'}, 400, jwt.get_token_cookie(user)
+            return {'error': 'User appspec must specify a creator'}, 400
         else:
             service_key = service['key']
             if is_service_key_unique(user, service_key):
                 new_spec = data_store.create_user_appspec(service)
-                return new_spec, 201, jwt.get_token_cookie(user)
+                return new_spec, 201
             else:
-                return {'error': 'Spec key already exists: %s' % service_key}, 409, jwt.get_token_cookie(user)
+                return {'error': 'Spec key already exists: %s' % service_key}, 409
     elif catalog == 'system':
         jwt.validate_scopes(['workbench-admin'], token_info)
         service_key = service['key']
         if is_service_key_unique(user, service_key):
             new_spec = data_store.create_system_appspec(service)
-            return new_spec, 201, jwt.get_token_cookie(user)
+            return new_spec, 201
         else:
-            return {'error': 'Spec key already exists: %s' % service_key}, 409, jwt.get_token_cookie(user)
+            return {'error': 'Spec key already exists: %s' % service_key}, 409
 
 
 def list_services_for_user(user, token_info):
@@ -105,38 +114,41 @@ def get_service_by_id(service_id, user, token_info):
 def update_service(service_id, service, user, token_info):
     spec_key = service['key']
     if spec_key != service_id:
-        return {'error': 'Key cannot be changed'}, 400, jwt.get_token_cookie(user)
+        return {'error': 'Key cannot be changed'}, 400
     catalog = service['catalog'] if 'catalog' in service else 'user'
 
     if catalog == 'user':
         existing_spec = data_store.retrieve_user_appspec_by_key(user, spec_key)
         if existing_spec is None:
-            return {'error': 'cannot update user app spec: user spec not found with key=%s' % spec_key}, 404, jwt.get_token_cookie(user)
+            return {'error': 'cannot update user app spec: user spec not found with key=%s' % spec_key}, 404
         if user != existing_spec['creator']:
-            return {'error': 'appspec only allows editing by the creator'}, 403, jwt.get_token_cookie(user)
+            return {'error': 'appspec only allows editing by the creator'}, 403
         if 'creator' in service and existing_spec['creator'] != service['creator']:
-            return {'error': 'appspec cannot change creator'}, 403, jwt.get_token_cookie(user)
+            return {'error': 'appspec cannot change creator'}, 403
+
+        # Do not let user modify ID
+        service['_id'] = existing_spec['_id']
 
         # TODO: should we use NotModified?
         updated = data_store.update_user_appspec(user, service)
         status_code = 200   # if updated > 0 else 304
-        return data_store.retrieve_user_appspec_by_key(user, spec_key), status_code, jwt.get_token_cookie(user)
+        return data_store.retrieve_user_appspec_by_key(user, spec_key), status_code
 
     elif catalog == 'system':
         # Admins only: check token for required roles
         jwt.validate_scopes(['workbench-admin'], token_info)
         existing_spec = data_store.retrieve_system_appspec_by_key(spec_key)
         if existing_spec is None:
-            return {'error': 'cannot update system app spec: system spec not found with key=%s' % spec_key}, 404, jwt.get_token_cookie(user)
+            return {'error': 'cannot update system app spec: system spec not found with key=%s' % spec_key}, 404
 
         # TODO: should we use NotModified?
         updated = data_store.update_system_appspec(service)
         # TODO: check matched_count vs modified_count?
         status_code = 200 if updated.modified_count > 0 else 304
-        return data_store.retrieve_system_appspec_by_key(spec_key), status_code, jwt.get_token_cookie(user)
+        return data_store.retrieve_system_appspec_by_key(spec_key), status_code
 
     else:
-        return {'error': 'appspec must have a valid catalog value'}, 400, jwt.get_token_cookie(user)
+        return {'error': 'appspec must have a valid catalog value'}, 400
 
 
 def delete_service(service_id, user, token_info):
@@ -150,9 +162,9 @@ def delete_service(service_id, user, token_info):
 
         # Verify deletion was successful using deleted_count
         if deleted.deleted_count > 0:
-            return 204, jwt.get_token_cookie(user)
+            return 204
         else:
-            return {'error': 'Failed to delete user spec key=%s: deletion failed' % service_id}, 500, jwt.get_token_cookie(user)
+            return {'error': 'Failed to delete user spec key=%s: deletion failed' % service_id}, 500
 
     # Admins only: check token for required role
     jwt.validate_scopes(['workbench-admin'], token_info)
@@ -165,12 +177,12 @@ def delete_service(service_id, user, token_info):
 
         # Verify deletion was successful using deleted_count
         if deleted.deleted_count > 0:
-            return 204, jwt.get_token_cookie(user)
+            return 204
         else:
-            return {'error': 'Failed to delete system spec key=%s: deletion failed' % service_id}, 500, jwt.get_token_cookie(user)
+            return {'error': 'Failed to delete system spec key=%s: deletion failed' % service_id}, 500
 
     else:
-        return {'error': 'Spec key=%s not found in either user or system catalog' % service_id}, 404, jwt.get_token_cookie(user)
+        return {'error': 'Spec key=%s not found in either user or system catalog' % service_id}, 404
 
 
 


### PR DESCRIPTION
## Problem
`MyCatalogPage` will need a cloneSpec function

## Approach
* Updates to `create_service` to support the idea of passing it a previously-created service to be copied
* Avoid adding a new API endpoint, if possible