### PR TITLE
Override Docker image command/args at runtime

### DIFF
--- a/pkg/kube.py
+++ b/pkg/kube.py
@@ -556,6 +556,7 @@ def create_userapp(username, userapp, spec_map):
             'resourceLimits': stack_service['resourceLimits'] if 'resourceLimits' in stack_service else app_spec[
                 'resourceLimits'] if 'resourceLimits' in app_spec else {},
             'command': stack_service['command'] if 'command' in stack_service else None,
+            'args': stack_service['args'] if 'args' in stack_service else None,
             'image': stack_service['image'] if 'image' in stack_service else app_spec['image'],
             'configmap': resource_name,
             'security_context': app_spec['securityContext'] if 'securityContext' in app_spec else None,
@@ -995,6 +996,7 @@ def create_deployment(deployment_name, containers, labels, username, **kwargs):
             client.V1Container(
                 name=container['name'],
                 command=container['command'],
+                args=container['args'],
                 security_context=client.V1SecurityContext(
                     capabilities=client.V1Capabilities(
                         add=container['security_context']['capabilities']['add'] if 'add' in container['security_context']['capabilities'] else None

--- a/pkg/kube.py
+++ b/pkg/kube.py
@@ -555,8 +555,10 @@ def create_userapp(username, userapp, spec_map):
             'name': stack_service_id,
             'resourceLimits': stack_service['resourceLimits'] if 'resourceLimits' in stack_service else app_spec[
                 'resourceLimits'] if 'resourceLimits' in app_spec else {},
-            'command': stack_service['command'] if 'command' in stack_service else None,
-            'args': stack_service['args'] if 'args' in stack_service else None,
+            'command': stack_service['command'] if 'command' in stack_service else app_spec[
+                'command'] if 'command' in app_spec else None,
+            'args': stack_service['args'] if 'args' in stack_service else app_spec[
+                'args'] if 'args' in app_spec else None,
             'image': stack_service['image'] if 'image' in stack_service else app_spec['image'],
             'configmap': resource_name,
             'security_context': app_spec['securityContext'] if 'securityContext' in app_spec else None,


### PR DESCRIPTION
## Problem
Our API lets us specify `command` for an appspec, but this command does not seem to be used when running the container

Overriding the userapp.services.command lets us do this, but it does not automatically use the command from the appspec

In addition, `args` are completely ignored in the spec

## Approach
* Pass `args` into `create_deployment`
* Use `app_spec` command if `stack_service` does not define one when creating the userapp

## How to Test
1. Checkout and run this branch locally
2. Import a new AppSpec the overrides `command`, for an example see https://github.com/cheese-hub/catalog/pull/15
    * Note that https://github.com/nds-org/workbench-webui/issues/17 describes a set of changes needed to create this spec using the UI, which is not yet possible
4. Create a new UserApp from this AppSpec (click + on All Apps page or use Swagger UI)
5. Launch the UserApp and wait for it to finish starting up
    * You should see the app turn green in the UI
6. Check `kubectl get pods -n <namespace>` and make sure container isn't Restarting over and over again