### PR TITLE
[WIP] feat: prefer traefik for localdev

### DIFF
--- a/env/backend.json
+++ b/env/backend.json
@@ -45,7 +45,7 @@
           "*.kubernetes.docker.internal"
         ]
       },
-      "class": "nginx",
+      "class": "traefik",
       "enabled": true
     }
   },


### PR DESCRIPTION
## Problems
Our prod deployments use Traefik

It would be nice to use this for localdev as well

Related to https://github.com/nds-org/workbench-helm-chart/pull/48

## Approach
* Change default `ingressClassName` used when creating Ingress rules for UserApps

## How to Test
For testing instructions, see https://github.com/nds-org/workbench-helm-chart/pull/48 