### PR TITLE
fix: use same protocol when forming endpoint links

### DIFF
--- a/pkg/config.py
+++ b/pkg/config.py
@@ -33,6 +33,8 @@ DOMAIN = os.getenv('DOMAIN', backend_config['domain'] if 'domain' in backend_con
 SSL_VERIFY = os.getenv('INSECURE_SSL_VERIFY',
                        backend_config['insecure_ssl_verify'] if 'insecure_ssl_verify' in backend_config else 'false'
                        ).lower() in ('true', '1', 't')
+FRONTEND_PROTOCOL = os.getenv('FRONTEND_PROTOCOL', frontend_config['domain'].split('://')[0] if 'domain' in frontend_config else 'https')
+
 
 # MongoStore
 MONGO_URI = os.getenv('MONGO_URI', backend_config['mongo']['uri'])

--- a/pkg/kube.py
+++ b/pkg/kube.py
@@ -106,7 +106,7 @@ def determine_new_endpoints(userapp_id, username, service_key, conditions):
                         'path': path,
                         # 'port': ':',       # unused
                         # 'nodePort': ':',   # unused
-                        'url': '%s://%s%s' % (protocol, host, path),
+                        'url': '%s://%s%s' % (config.FRONTEND_PROTOCOL, host, path),
                     }
 
                     logger.debug('Adding endpoint: %s' % endpoint)


### PR DESCRIPTION
## Problem
When forming links, Workbench appears to use the Kubernetes endpoint `protocol` (may always be HTTP)

In prod (and localdev), we should prefer HTTPS

## Approach
* fix: use the same protocol that is set on the root frontend domain when forming endpoint links

## How to Test
1. Checkout and run this branch locally (see [workbench-helm-chart](https://github.com/nds-org/workbench-helm-chart))
2. Navigate to https://kubernetes.docker.internal/ (ignore browser certificate warnings)
3. Login/register with Keycloak
    * You should be brought back to the Workbench, now logged in
4. Add an application from the "All Apps"
    * You should be brought to "My Apps" to see your new app
6. Launch the application
    * You should see the application turn green when it is ready
7. Click the link to navigate to your app (ignore browser certificate warnings)
    * You should see the UI for your app load in the browser