### PR TITLE
feat: set a few additional envvars to pass context to apps

### DIFF
--- a/api/v1/user_apps.py
+++ b/api/v1/user_apps.py
@@ -59,7 +59,9 @@ def to_spec_map(specs, existing_map=None):
 
 
 def create_userapp(stack, user, token_info):
+    logger.info('token_info=%s' % token_info)
     username = kube.get_username(user)
+    user_email = token_info['email']
     stack['creator'] = username
     stack_id = generate_unique_id(user)
     stack['id'] = stack['_id'] = stack_id
@@ -84,7 +86,7 @@ def create_userapp(stack, user, token_info):
         kube.init_user(username=user)
 
         # Create service(s) / ingress / deployment
-        kube.create_userapp(username=username, userapp=stack, spec_map=spec_map)
+        kube.create_userapp(username=username, email=user_email, userapp=stack, spec_map=spec_map)
 
         # Save metadata to database
         stack = data_store.create_userapp(stack)

--- a/pkg/kube.py
+++ b/pkg/kube.py
@@ -501,7 +501,8 @@ def create_userapp(username, userapp, spec_map):
         stack_service_id = get_stack_service_id(userapp_id, service_key)
         resource_name = get_resource_name(get_username(username), userapp_id, service_key)
         service_ports = app_spec['ports'] if 'ports' in app_spec else []
-        ingress_hosts[resource_name] = service_ports
+        if app_spec['access'] == 'external':
+            ingress_hosts[resource_name] = service_ports
 
         # Build up config from userapp env/config and appspec config
         configmap_data = stack_service['config'] if 'config' in stack_service else {}
@@ -520,6 +521,10 @@ def create_userapp(username, userapp, spec_map):
             else:
                 configmap_data[cfg['name']] = cfg['value'] if 'value' in cfg else ''
 
+        configmap_data['NDSLABS_STACK'] = userapp_id
+        configmap_data['NDSLABS_USER'] = username
+        configmap_data['NDSLABS_NAMESPACE'] = namespace
+        configmap_data['NDSLABS_SERVICE'] = stack_service['id']
         stack_service['config'] = configmap_data
 
         # TODO: Support custom volume mounts?

--- a/pkg/kube.py
+++ b/pkg/kube.py
@@ -525,6 +525,7 @@ def create_userapp(username, userapp, spec_map):
         configmap_data['NDSLABS_USER'] = username
         configmap_data['NDSLABS_NAMESPACE'] = namespace
         configmap_data['NDSLABS_SERVICE'] = stack_service['id']
+        configmap_data['NDSLABS_DOMAIN'] = config.DOMAIN
         stack_service['config'] = configmap_data
 
         # TODO: Support custom volume mounts?

--- a/pkg/kube.py
+++ b/pkg/kube.py
@@ -475,7 +475,7 @@ def get_init_container(username, spec_key, svc_key):
 
 
 # Creates the Kubernetes resources related to a userapp
-def create_userapp(username, userapp, spec_map):
+def create_userapp(username, email, userapp, spec_map):
     namespace = get_resource_namespace(username)
     containers = []
     ingress_hosts = {}
@@ -523,6 +523,7 @@ def create_userapp(username, userapp, spec_map):
 
         configmap_data['NDSLABS_STACK'] = userapp_id
         configmap_data['NDSLABS_USER'] = username
+        configmap_data['NDSLABS_EMAIL'] = email
         configmap_data['NDSLABS_NAMESPACE'] = namespace
         configmap_data['NDSLABS_SERVICE'] = stack_service['id']
         configmap_data['NDSLABS_DOMAIN'] = config.DOMAIN


### PR DESCRIPTION
## Problems
Some applications rely on legacy envvars that were set in Workbench V1 (for example, [cloudcmd](https://github.com/nds-org/ndslabs-specs/blob/43ed0bd64badefc016a9369d2a0ae8f88613eab8/system/cloudcmd.json#L18))

Workbench V2 should also set similar values, so that these applications can be used in V2

List of potentially affected apps:
* CKAN (PostgreSQL ADDR/PORT may still be present)
* Girder (MongoDB ADDR/PORT may still be present)
* Suave (MongoDB ADDR may still be present)
* CloudCmd (NAMESPACE)
* CHORDS? (CHORDS_ADMIN_PW should still be present)
* DSpace (PostgreSQL ADDR / NDSLABS_EMAIL)
* Dataverse / TwoRavens (NDSLABS_STACK / NDSLABS_DOMAIN)

## Approach
* feat: set a few additional envvars to pass context to apps

## How to Test
1. Checkout and run this branch locally (see [workbench-helm-chart](https://github.com/nds-org/workbench-helm-chart))
2. Navigate to https://kubernetes.docker.internal/ (ignore browser certificate warnings)
3. Login/register with Keycloak
    * You should be brought back to the Workbench, now logged in
4. Add an application from the "All Apps"
    * You should be brought to "My Apps" to see your new app
6. Launch the application
    * You should see the application turn green when it is ready
7. Click the Console link on the "My Apps" page
    * You should see a web terminal open in your browser
8. In the Console, type `env | grep NDSLABS_`
    * You should see the values of 4 additional variables are printed: `NDSLABS_STACK`, `NDSLABS_USER`, `NDSLABS_NAMESPACE`, `NDSLABS_SERVICE`