### PR TITLE
temp fix: pin to Python 3.9 to fix PyYAML install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9
 WORKDIR /app
 
 COPY requirements.txt .


### PR DESCRIPTION
## Problem
Python 3.10+ breaks installation of `PyYAML` 5.4.1

We can't downgrade PyYaml, since `kubernetes` requires at least 5.4.1

## Approach
* temp fix: Pin to Python 3.9 for now

A better approach in the long-term might be to upgrade Python and/or PyYAML versions

## How to Test
Wait for automated build to complete successfully